### PR TITLE
Add manual version to manifest.json.

### DIFF
--- a/custom_components/modernforms/manifest.json
+++ b/custom_components/modernforms/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": [],
   "codeowners": ["jimpastos"],
   "requirements": [],
-  "config_flow": true
+  "config_flow": true,
+  "version": "202101311417"
 }


### PR DESCRIPTION
This is to address the immediate issue #7 by adding the version as the date as the last commit to the `master` branch.

Ideally, this could/should be automated via some sort of GitHub action. Like an [example from this StackOverflow thread](https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action). Complexity there is that it likely requires splitting the "release" and "master" branches, but I leave that to the maintainer to address. I just want this to continue working after June HA release :-).