### PR TITLE
Increase scan interval to 60 secons to address issue #11.

### DIFF
--- a/custom_components/modernforms/__init__.py
+++ b/custom_components/modernforms/__init__.py
@@ -11,7 +11,7 @@ from .const import DOMAIN, DEVICES, CONF_FAN_NAME, CONF_FAN_HOST, CONF_ENABLE_LI
 _LOGGER = logging.getLogger(__name__)
 
 CONF_LIGHT = "light"
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=60)
 
 def setup(hass, config):
   hass.data[DOMAIN] = {}

--- a/custom_components/modernforms/__init__.py
+++ b/custom_components/modernforms/__init__.py
@@ -11,7 +11,7 @@ from .const import DOMAIN, DEVICES, CONF_FAN_NAME, CONF_FAN_HOST, CONF_ENABLE_LI
 _LOGGER = logging.getLogger(__name__)
 
 CONF_LIGHT = "light"
-SCAN_INTERVAL = timedelta(seconds=60)
+SCAN_INTERVAL = 60
 
 def setup(hass, config):
   hass.data[DOMAIN] = {}
@@ -21,7 +21,7 @@ def setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
   fan = config_entry.data
-  scan_interval = fan.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+  scan_interval = timedelta(seconds=fan.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL))
   name = fan.get(CONF_FAN_NAME)
   host = fan.get(CONF_FAN_HOST)
   has_light = fan.get(CONF_ENABLE_LIGHT)

--- a/custom_components/modernforms/manifest.json
+++ b/custom_components/modernforms/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": [],
   "codeowners": ["jimpastos"],
   "requirements": [],
-  "config_flow": true
+  "config_flow": true,
+  "version": "202101311417"
 }


### PR DESCRIPTION
This PR addresses the issue #11 by simply bumping the configured scan_interval to 60 seconds.

I was trying to figure out how to configure a custom scan interval in the config, but for example this didn't work:

`configuration.yaml`
```
fan:
- platform: modernforms
  scan_interval: 60
```