### PR TITLE
Changes to docker_compose.yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ On the integrations page, click "Add Integration" and search for "Modern Forms" 
 
 ## Contributing
 
-To test changes locally you can use [Docker Compose](https://docs.docker.com/compose/)
+To test changes locally you can use [Docker Compose](https://docs.docker.com/compose/). If you want log output in your local timezone, instead of UTC, you will need to specify `TZ` variable value.
 
 Start Home Assistant:
 ```bash
-docker-compose up
+TZ="$(cat /etc/timezone)" docker-compose up
 ```
 
 This will create the normal `config` directory in `.config`. Once done, you probably will want to configure your logging:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,20 @@
 version: '3'
 services:
   homeassistant:
-    container_name: home-assistant
+    container_name: modern-forms-home-assistant
     image: homeassistant/home-assistant:stable
     volumes:
       - .config:/config
       - ./custom_components:/config/custom_components
     environment:
-      - TZ=America/New_York
-    restart: always
+      - TZ
     ports:
-      - 8123:8123
-    network_mode: "bridge"
+      - 8223:8123
+    networks:
+      - modern-forms-home-assistant
+    restart: always
+
+networks: 
+  modern-forms-home-assistant:
+    name: modern-forms-home-assistant
+    driver: bridge


### PR DESCRIPTION
- Changed the `container_name` to make it less likely to overlap with Home Assistant proper.
- Adjusted TZ handling, as `America/New_York` is unlikely to be correct value for everyone.
- Moved exported port to 8223 to make it less likely to overlap with Home Assistant proper.
- Explicit network configuration.